### PR TITLE
chore: add diesel crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4391a22b19c916e50bec4d6140f29bdda3e3bb187223fe6e3ea0b6e4d1021c04"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "diesel_derives",
+ "itoa",
+ "pq-sys",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1712,7 @@ dependencies = [
 name = "papr-server-rs"
 version = "0.1.0"
 dependencies = [
+ "diesel",
  "eyre",
  "graphql_client",
  "once_cell",
@@ -1839,6 +1865,15 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pq-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b845d6d8ec554f972a2c5298aad68953fd64e7441e846075450b44656a016d1"
+dependencies = [
+ "vcpkg",
+]
 
 [[package]]
 name = "prettyplease"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ eyre = "0.6.8"
 once_cell = "1.17"
 tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "macros"] }
 reservoir-nft = "0.1.4"
+diesel = { version = "2.0.3", features = ["postgres"] }


### PR DESCRIPTION
https://diesel.rs/guides/getting-started

This seems to be one of the 2 main choices for DB work in rust (the other being https://github.com/launchbadge/sqlx). Diesel seems to be more performant and the schema validation doesn't require a database at build time.